### PR TITLE
Fix timer issue

### DIFF
--- a/Core/Inc/hw_conf.h
+++ b/Core/Inc/hw_conf.h
@@ -109,7 +109,7 @@
  * The user may define the maximum number of virtual timers supported.
  * It shall not exceed 255
  */
-#define CFG_HW_TS_MAX_NBR_CONCURRENT_TIMER  12
+#define CFG_HW_TS_MAX_NBR_CONCURRENT_TIMER  14
 
 /**
  * The user may define the priority in the NVIC of the RTC_WKUP interrupt handler that is used to manage the

--- a/Core/Inc/hw_if.h
+++ b/Core/Inc/hw_if.h
@@ -245,6 +245,14 @@ extern "C" {
    */
   void HW_TS_RTC_CountUpdated_AppNot(void);
 
+  /**
+   * @brief  Count the number of timers used
+   *
+   * @param  None
+   * @retval The number of timers used
+   */
+  uint8_t HW_TS_CountUsed();
+
 #ifdef __cplusplus
 }
 #endif

--- a/Core/Src/hw_timerserver.c
+++ b/Core/Src/hw_timerserver.c
@@ -891,3 +891,28 @@ __weak void HW_TS_RTC_Int_AppNot(uint32_t TimerProcessID, uint8_t TimerID, HW_TS
 
   return;
 }
+
+uint8_t HW_TS_CountUsed()
+{
+  uint8_t ret = 0;
+  uint8_t loop = 0;
+#if (CFG_HW_TS_USE_PRIMASK_AS_CRITICAL_SECTION == 1)
+  uint32_t primask_bit;
+#endif
+
+#if (CFG_HW_TS_USE_PRIMASK_AS_CRITICAL_SECTION == 1)
+  primask_bit = __get_PRIMASK();  /**< backup PRIMASK bit */
+  __disable_irq();          /**< Disable all interrupts by setting PRIMASK bit on Cortex*/
+#endif
+
+  while((loop < CFG_HW_TS_MAX_NBR_CONCURRENT_TIMER))
+  {
+    if (aTimerContext[loop].TimerIDStatus != TimerID_Free) ret++;
+    loop++;
+  }
+#if (CFG_HW_TS_USE_PRIMASK_AS_CRITICAL_SECTION == 1)
+  __set_PRIMASK(primask_bit); /**< Restore PRIMASK bit*/
+#endif
+
+  return(ret);
+}

--- a/FlySight/active_mode.c
+++ b/FlySight/active_mode.c
@@ -74,6 +74,12 @@ void FS_ActiveMode_Init(void)
 	{
 		// Enable logging
 		FS_Log_Init(FS_State_Get()->temp_folder);
+
+		// Log timer usage adjusted for:
+		//   - FS_Control_Init
+		//   - FS_Log_Init
+		FS_Log_WriteEvent("%lu/%lu timers used before active mode initialization",
+				HW_TS_CountUsed() - 2, CFG_HW_TS_MAX_NBR_CONCURRENT_TIMER);
 	}
 
 	if (FS_Config_Get()->enable_audio)
@@ -231,6 +237,12 @@ void FS_ActiveMode_DeInit(void)
 
 	if (FS_Config_Get()->enable_logging)
 	{
+		// Log timer usage adjusted for:
+		//   - FS_Log_DeInit
+		FS_Log_WriteEvent("----------");
+		FS_Log_WriteEvent("%lu/%lu timers used after active mode de-initialization",
+				HW_TS_CountUsed() - 1, CFG_HW_TS_MAX_NBR_CONCURRENT_TIMER);
+
 		// Disable logging
 		FS_Log_DeInit(FS_State_Get()->temp_folder);
 	}

--- a/FlySight/config_mode.c
+++ b/FlySight/config_mode.c
@@ -44,12 +44,13 @@ static uint8_t timer_id;
 
 typedef enum
 {
+	STATE_IDLE,
 	STATE_PLAY,
 	STATE_WAIT,
 	STATE_DONE
 } State_t;
 
-static State_t state;
+static State_t state = STATE_IDLE;
 
 static char config_filename[13];
 
@@ -246,6 +247,9 @@ void FS_ConfigMode_DeInit(void)
 
 	// Disable VCC
 	HAL_GPIO_WritePin(VCC_EN_GPIO_Port, VCC_EN_Pin, GPIO_PIN_RESET);
+
+	// Reset state
+	state = STATE_IDLE;
 }
 
 const char *FS_ConfigMode_GetConfigFilename(void)


### PR DESCRIPTION
Fix an issue which caused a "leak" of timers, which eventually caused the GNSS update task not to be called.