### PR TITLE
Handle microSD conflict

### DIFF
--- a/FlySight/resource_manager.h
+++ b/FlySight/resource_manager.h
@@ -34,8 +34,14 @@ typedef enum
 	FS_RESOURCE_COUNT
 } FS_Resource_t;
 
+typedef enum
+{
+	FS_RESOURCE_MANAGER_SUCCESS,
+	FS_RESOURCE_MANAGER_FAILURE
+} FS_ResourceManager_Result_t;
+
 void FS_ResourceManager_Init(void);
-void FS_ResourceManager_RequestResource(FS_Resource_t resource);
+FS_ResourceManager_Result_t FS_ResourceManager_RequestResource(FS_Resource_t resource);
 void FS_ResourceManager_ReleaseResource(FS_Resource_t resource);
 
 #endif /* RESOURCE_MANAGER_H_ */


### PR DESCRIPTION
Handle a conflict in microSD use between the BLE CRS features and USB/active modes. For now, this is being handled by ensuring that the CRS never accesses the disk when the unit is in USB or active mode. If possible, we may want to make this more granular, so that it is possible to review jumps while the unit is logging.