### PR TITLE
Fix GET_DEVICE_ID control point response

### DIFF
--- a/Docs/ble.md
+++ b/Docs/ble.md
@@ -332,7 +332,7 @@ Provides information about the device's current operational state and allows for
         *   **Write Operations (Central to FlySight):**
             *   `0x01` (`DS_CMD_GET_FW_VERSION`): Get firmware version string. Payload: none.
             *   `0x02` (`DS_CMD_REBOOT_DEVICE`): Gracefully return to sleep, then reset. Payload: none.
-            *   `0x03` (`DS_CMD_GET_DEVICE_ID`): Get device ID. Payload: none.
+            *   `0x03` (`DS_CMD_GET_DEVICE_ID`): Get device ID. Payload: none. Response data: 12 raw bytes, the three `uint32` words of the device ID in little-endian byte order (formatting each word as `%08x` reproduces the `Device_ID` string from `FLYSIGHT.TXT`).
             *   `0x04` (`DS_CMD_INSTALL_UPLOADED_FIRMWARE`): Gracefully return to sleep, write `STANDALONE_LOADER_DWL_REQ` to the bootloader mailbox, then reset. Payload: none.
             *   `0x10` (`DS_CMD_REQUEST_SLEEP`): Request sleep mode. Accepted from active, start, config, pairing, or sleep. Rejected from USB.
             *   `0x11` (`DS_CMD_REQUEST_ACTIVE`): Request active mode. Accepted only from sleep.

--- a/FlySight/device_state.c
+++ b/FlySight/device_state.c
@@ -101,21 +101,6 @@ void DeviceState_Init(void) {
                  hw_ts_SingleShot, response_fallback_timer);
 }
 
-// Helper to convert a uint32_t array (like device ID) to a hex string
-static void uint32_array_to_hex_string(const uint32_t *data, uint32_t count, char *out_str, size_t out_str_len) {
-    size_t offset = 0;
-    for (uint32_t i = 0; i < count; ++i) {
-        int written = snprintf(out_str + offset, out_str_len - offset, "%08lx", data[i]);
-        if (written < 0 || (size_t)written >= (out_str_len - offset)) {
-            // Buffer too small or error
-            if (offset < out_str_len) out_str[offset] = '\0'; // Ensure null termination if possible
-            return;
-        }
-        offset += written;
-    }
-}
-
-
 void DeviceState_Handle_DS_ControlPointWrite(const uint8_t *payload, uint8_t length,
                                              uint16_t conn_handle, uint8_t notification_enabled_flag) {
     (void)conn_handle;
@@ -167,17 +152,12 @@ void DeviceState_Handle_DS_ControlPointWrite(const uint8_t *payload, uint8_t len
                 if (params_len != 0) {
                     status = CP_STATUS_INVALID_PARAMETER;
                 } else {
-                    char hex_id_str[25]; // 3 * 8 hex chars + null
-                    uint32_array_to_hex_string(FS_State_Get()->device_id, 3, hex_id_str, sizeof(hex_id_str));
-
-                    response_data_len = strlen(hex_id_str);
-                    if (response_data_len <= MAX_CP_OPTIONAL_RESPONSE_DATA_LEN) {
-                         memcpy(response_data_buf, hex_id_str, response_data_len);
-                         status = CP_STATUS_SUCCESS;
-                    } else {
-                        status = CP_STATUS_ERROR_UNKNOWN; // Buffer too small for ID string
-                        response_data_len = 0;
-                    }
+                    // 12 raw bytes: the previous 24-character hex string
+                    // exceeded MAX_CP_OPTIONAL_RESPONSE_DATA_LEN, so this
+                    // command could never succeed
+                    memcpy(response_data_buf, FS_State_Get()->device_id, 12);
+                    response_data_len = 12;
+                    status = CP_STATUS_SUCCESS;
                 }
                 break;
 


### PR DESCRIPTION
`DS_CMD_GET_DEVICE_ID` (0x03) has never been able to succeed: the handler formats the device ID as a 24-character hex string, but `MAX_CP_OPTIONAL_RESPONSE_DATA_LEN` is 17, so its own length check always fails and the command returns `ERROR_UNKNOWN`. Easy to reproduce with any BLE client — we ran into it on B6 hardware while exercising the new control point commands.

This returns the 12 raw bytes of the device ID instead: the three `uint32` words in little-endian byte order, so formatting each word as `%08x` reproduces the `Device_ID` string from `FLYSIGHT.TXT`. The response fits well within the existing limits (12 ≤ 17 optional bytes, 3+12 ≤ 20 characteristic bytes), and since the command never succeeded, no client can be depending on the string format. The now-unused hex helper is removed and `Docs/ble.md` updated.

An alternative would be to enlarge `MAX_CP_OPTIONAL_RESPONSE_DATA_LEN` and the control point characteristics, which would also lift the 16-character truncation of `GET_FW_VERSION` responses — happy to rework in that direction instead if you prefer.
